### PR TITLE
NewClient helper added

### DIFF
--- a/securionpay.go
+++ b/securionpay.go
@@ -39,6 +39,17 @@ func NewClientFromEnv() (*Client, error) {
 	return client, nil
 }
 
+// NewClient first tries all the apiKeys provided as arguments,
+// if it finds a non blank one, uses that.
+// Otherwise it falls back to finding the API key from the environment.
+func NewClient(apiKeysToTry ...string) (*Client, error) {
+	nonBlankAPIKey := otils.FirstNonEmptyString(apiKeysToTry...)
+	if nonBlankAPIKey != "" {
+		return &Client{apiKey: nonBlankAPIKey}, nil
+	}
+	return NewClientFromEnv()
+}
+
 func (c *Client) SetHTTPRoundTripper(rt http.RoundTripper) {
 	c.Lock()
 	c.rt = rt


### PR DESCRIPTION
An initializer that takes in a list of API keys, using the
first non blank API key otherwise it falls back to retrieving
the API key from the environment.

Sample usage:
```go
client, err := securionpay.NewClient()
```